### PR TITLE
Add category enum items #23

### DIFF
--- a/infra/migrations/1763429470332_add-category-column-in-items.js
+++ b/infra/migrations/1763429470332_add-category-column-in-items.js
@@ -1,5 +1,3 @@
-exports.shorthands = {};
-
 exports.up = (pgm) => {
     pgm.createType(
         "item_category_enum",
@@ -32,15 +30,4 @@ exports.up = (pgm) => {
     pgm.alterColumn("items", "category", { default: null });
 };
 
-exports.down = (pgm) => {
-    pgm.addColumn("items", {
-        category_id: {
-            type: "uuid",
-            notNull: false,
-        },
-    });
-
-    pgm.dropColumn("items", "category");
-
-    pgm.dropType("item_category_enum");
-};
+exports.down = false;

--- a/infra/migrations/1763429470332_add-category-enum-to-items.js
+++ b/infra/migrations/1763429470332_add-category-enum-to-items.js
@@ -1,0 +1,46 @@
+exports.shorthands = {};
+
+exports.up = (pgm) => {
+    pgm.createType(
+        "item_category_enum",
+
+        [
+            "Laticínios",
+            "Temperos",
+            "Carnes e Aves",
+            "Peixes e Frutos do Mar",
+            "Frutas",
+            "Legumes e Verduras",
+            "Grãos e Cereais",
+            "Congelados",
+            "Padaria",
+            "Bebidas",
+            "Outros",
+        ],
+    );
+
+    pgm.addColumn("items", {
+        category: {
+            type: "item_category_enum",
+            notNull: true,
+            default: "Outros",
+        },
+    });
+
+    pgm.dropColumn("items", "category_id");
+
+    pgm.alterColumn("items", "category", { default: null });
+};
+
+exports.down = (pgm) => {
+    pgm.addColumn("items", {
+        category_id: {
+            type: "uuid",
+            notNull: false,
+        },
+    });
+
+    pgm.dropColumn("items", "category");
+
+    pgm.dropType("item_category_enum");
+};

--- a/models/item.js
+++ b/models/item.js
@@ -15,7 +15,7 @@ async function create(itemData) {
             validatedItemData.quantity,
             validatedItemData.unit,
             validatedItemData.expiration_date || null,
-            validatedItemData.category || null,
+            validatedItemData.category,
         ],
     };
 
@@ -121,8 +121,6 @@ function validateItemData(data) {
                 message: '"category" must be a String.',
             });
         }
-
-        validateUUID("category", data.category);
     }
 
     return {

--- a/models/item.js
+++ b/models/item.js
@@ -6,7 +6,7 @@ async function create(itemData) {
 
     const query = {
         text: `
-            INSERT INTO items (name, quantity, unit, expiration_date, category_id)
+            INSERT INTO items (name, quantity, unit, expiration_date, category)
             VALUES ($1, $2, $3, $4, $5)
             RETURNING *;
         `,
@@ -15,7 +15,7 @@ async function create(itemData) {
             validatedItemData.quantity,
             validatedItemData.unit,
             validatedItemData.expiration_date || null,
-            validatedItemData.category_id || null,
+            validatedItemData.category || null,
         ],
     };
 
@@ -115,14 +115,14 @@ function validateItemData(data) {
         }
     }
 
-    if (data.category_id !== undefined && data.category_id !== null) {
-        if (typeof data.category_id !== "string") {
+    if (data.category !== undefined && data.category !== null) {
+        if (typeof data.category !== "string") {
             throw new ValidationError({
-                message: '"category_id" must be a String.',
+                message: '"category" must be a String.',
             });
         }
 
-        validateUUID("category_id", data.category_id);
+        validateUUID("category", data.category);
     }
 
     return {
@@ -130,7 +130,7 @@ function validateItemData(data) {
         quantity: data.quantity,
         unit: trimmedUnit,
         expiration_date: data.expiration_date || null,
-        category_id: data.category_id || null,
+        category: data.category || null,
     };
 }
 
@@ -144,7 +144,7 @@ async function list() {
                     quantity,
                     unit,
                     expiration_date,
-                    category_id,
+                    category,
                     created_at,
                     updated_at
                 FROM 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-    "name": "clone-tabnews",
+    "name": "smart-kitchen",
     "version": "1.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
-            "name": "clone-tabnews",
+            "name": "smart-kitchen",
             "version": "1.0.0",
             "license": "MIT",
             "dependencies": {

--- a/tests/integration/api/v1/items/get.test.js
+++ b/tests/integration/api/v1/items/get.test.js
@@ -30,7 +30,7 @@ describe("GET /api/v1/items", () => {
                 quantity: 6,
                 unit: "l",
                 expiration_date: "2025-10-15T00:00:00.000Z",
-                category: "550e8400-e29b-41d4-a716-446655440001",
+                category: "Laticínios",
             };
 
             const secondItemData = {
@@ -38,7 +38,7 @@ describe("GET /api/v1/items", () => {
                 quantity: 500,
                 unit: "g",
                 expiration_date: "2025-09-30T00:00:00.000Z",
-                category: "550e8400-e29b-41d4-a716-446655440003",
+                category: "Legumes e Verduras",
             };
 
             // Criar os itens
@@ -79,7 +79,7 @@ describe("GET /api/v1/items", () => {
             expect(firstReturnedItem).toHaveProperty("quantity");
             expect(firstReturnedItem).toHaveProperty("unit");
             expect(firstReturnedItem).toHaveProperty("expiration_date");
-            expect(firstReturnedItem).toHaveProperty("category_id");
+            expect(firstReturnedItem).toHaveProperty("category");
             expect(firstReturnedItem).toHaveProperty("created_at");
 
             // Verificar tipos dos campos
@@ -87,6 +87,7 @@ describe("GET /api/v1/items", () => {
             expect(typeof firstReturnedItem.name).toBe("string");
             expect(typeof firstReturnedItem.quantity).toBe("number");
             expect(typeof firstReturnedItem.unit).toBe("string");
+            expect(typeof firstReturnedItem.category).toBe("string");
             expect(typeof firstReturnedItem.created_at).toBe("string");
         });
 
@@ -100,6 +101,7 @@ describe("GET /api/v1/items", () => {
                 name: "Primeiro Item",
                 quantity: 1,
                 unit: "unidade",
+                category: "Laticínios",
             };
 
             await fetch(`http://localhost:3000/api/v1/items`, {
@@ -115,6 +117,7 @@ describe("GET /api/v1/items", () => {
                 name: "Segundo Item",
                 quantity: 2,
                 unit: "unidade",
+                category: "Legumes e Verduras",
             };
 
             await fetch(`http://localhost:3000/api/v1/items`, {

--- a/tests/integration/api/v1/items/get.test.js
+++ b/tests/integration/api/v1/items/get.test.js
@@ -30,7 +30,7 @@ describe("GET /api/v1/items", () => {
                 quantity: 6,
                 unit: "l",
                 expiration_date: "2025-10-15T00:00:00.000Z",
-                category_id: "550e8400-e29b-41d4-a716-446655440001",
+                category: "550e8400-e29b-41d4-a716-446655440001",
             };
 
             const secondItemData = {
@@ -38,7 +38,7 @@ describe("GET /api/v1/items", () => {
                 quantity: 500,
                 unit: "g",
                 expiration_date: "2025-09-30T00:00:00.000Z",
-                category_id: "550e8400-e29b-41d4-a716-446655440003",
+                category: "550e8400-e29b-41d4-a716-446655440003",
             };
 
             // Criar os itens

--- a/tests/integration/api/v1/items/post.test.js
+++ b/tests/integration/api/v1/items/post.test.js
@@ -1,33 +1,40 @@
 import orchestrator from "tests/orchestrator.js";
 
+const BASE_URL = "http://localhost:3000";
+
 beforeAll(async () => {
     await orchestrator.waitForAllServices();
     await orchestrator.clearDatabase();
     await orchestrator.runPendingMigrations();
-});
+}, 120000);
 
 describe("POST /api/v1/items", () => {
     describe("Creating items", () => {
         test("With valid data", async () => {
-            const response = await fetch(`http://localhost:3000/api/v1/items`, {
+            const payload = {
+                name: "Tomate",
+                quantity: 5,
+                unit: "kg",
+                category: "Legumes e Verduras",
+            };
+
+            const response = await fetch(`${BASE_URL}/api/v1/items`, {
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json",
                 },
-                body: JSON.stringify({
-                    name: "Tomate",
-                    quantity: 5,
-                    unit: "kg",
-                }),
+                body: JSON.stringify(payload),
             });
 
             expect(response.status).toBe(201);
 
             const responseBody = await response.json();
+
             expect(responseBody).toHaveProperty("id");
-            expect(responseBody.name).toBe("Tomate");
-            expect(responseBody.quantity).toBe(5);
-            expect(responseBody.unit).toBe("kg");
+            expect(responseBody.name).toBe(payload.name);
+            expect(responseBody.quantity).toBe(payload.quantity);
+            expect(responseBody.unit).toBe(payload.unit);
+            expect(responseBody.category).toBe(payload.category);
         });
     });
 });


### PR DESCRIPTION
refactor(tests/get): atualiza os valores que são enviados para a coluna category em items.

refactor(models/item.js) atualiza a validação na coluna category de items
remove as seguintes validações da coluna category:

permitir apenas uuids

permitir nulls

adiciona a seguinte validação à coluna category:

permitir apenas strings

refactor(test): renomeia category_id para category em ´items/get.test.js´

feat(db): adiciona migration para alterar a tabela items, de category_id -> category com tipo enum

refactor(test): atualiza o teste para o novo enum category na tabela items

feat(models): renomeia category_id para category em ´models/item.js´